### PR TITLE
Enable overwriting translation of(all) other plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-plugin=Overwrite_translation
-version=1.0.33.1
+plugin=zzzzOverwrite_translation
+version=1.0.34.0
 
 all:
 	@ echo "Build archive for plugin ${plugin} version=${version}"

--- a/Plugin.php
+++ b/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kanboard\Plugin\Overwrite_translation;
+namespace Kanboard\Plugin\zzzzOverwrite_translation;
 
 use Kanboard\Core\Plugin\Base;
 use Kanboard\Core\Translator;
@@ -29,7 +29,7 @@ class Plugin extends Base {
     }
 
     public function getPluginVersion() {
-        return '1.0.33.0';
+        return '1.0.34.0';
     }
 
     public function getPluginHomepage() {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ There is sub-directory for each language, by example for the French we have fr_F
 A translation is a PHP file that returns an Array with a key-value pairs
 The key is the original text in english and the value is the translation for the corresponding language
 
+Because this plugin is most likely the last one to get executed within kanboard, you can also overwrite the translations that come with other plugins
+
 Author
 ------
 
@@ -21,5 +23,5 @@ Installation
 
 or
 
-- Create a folder **plugins/Overwrite_translation**
+- Create a folder **plugins/zzzzOverwrite_translation**
 - Copy all files under this directory


### PR DESCRIPTION
By changing the name of the folder _(not the plugins itself!)_ it is now most likely, that this plugin will get executed/rendered as the last plugin. This enables you to overwrite translations of any other plugin as well.

Have tested here on my local testboards ... 

Hope you like it